### PR TITLE
Add 3D Three.js demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This project underwent code refactoring after version `v1.0.0` and is currently 
   - 🎤 Voice interruption without headphones (AI won't hear its own voice)
   - 🫱 Touch feedback, interact with your AI companion through clicks or drags
   - 😊 Live2D expressions, set emotion mapping to control model expressions from the backend
+  - 🕶️ Experimental Three.js front-end showcasing a sample 3D avatar
   - 🐱 Pet mode, supporting transparent background, global top-most, and mouse click-through - drag your AI companion anywhere on the screen
   - 💭 Display AI's inner thoughts, allowing you to see AI's expressions, thoughts and actions without them being spoken
   - 🗣️ AI proactive speaking feature
@@ -100,6 +101,8 @@ This project underwent code refactoring after version `v1.0.0` and is currently 
 ## 🚀 Quick Start
 
 Please refer to the [Quick Start](https://open-llm-vtuber.github.io/docs/quick-start) section in our documentation for installation.
+
+After starting the server with `uv run run_server.py`, open `http://localhost:8000/threejs-demo/` to try the new Three.js demo interface. The page loads a sample glTF model from the web; edit `frontend_threejs/main.js` to load your own model.
 
 
 

--- a/frontend_threejs/index.html
+++ b/frontend_threejs/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Open-LLM-VTuber 3D</title>
+    <style>
+        body, html { margin: 0; height: 100%; overflow: hidden; background: #000; }
+        #renderArea { width: 100%; height: 80%; display: block; }
+        #chat { position: absolute; bottom: 0; width: 100%; padding: 10px; background: rgba(0,0,0,0.5); }
+        #messages { height: 150px; overflow-y: auto; color: #fff; font-family: Arial, sans-serif; margin-bottom: 5px; }
+        #userInput { width: 80%; }
+    </style>
+</head>
+<body>
+    <canvas id="renderArea"></canvas>
+    <div id="chat">
+        <div id="messages"></div>
+        <input type="text" id="userInput" placeholder="Type your message" />
+        <button id="sendBtn">Send</button>
+    </div>
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/frontend_threejs/main.js
+++ b/frontend_threejs/main.js
@@ -1,0 +1,123 @@
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import { GLTFLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+
+const canvas = document.getElementById('renderArea');
+const scene = new THREE.Scene();
+
+const camera = new THREE.PerspectiveCamera(
+    45,
+    canvas.clientWidth / canvas.clientHeight,
+    0.1,
+    100,
+);
+camera.position.set(0, 1.6, 3);
+
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 1.2, 0);
+controls.update();
+
+const hemiLight = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+hemiLight.position.set(0, 2, 0);
+scene.add(hemiLight);
+
+const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+dirLight.position.set(2, 4, 2);
+scene.add(dirLight);
+
+let avatar;
+new GLTFLoader().load(
+    'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RobotExpressive/glTF/RobotExpressive.glb',
+    (gltf) => {
+        avatar = gltf.scene;
+        avatar.position.set(0, 0, 0);
+        scene.add(avatar);
+    },
+    undefined,
+    (err) => console.error('Avatar load error', err),
+);
+
+let audioPlaying = false;
+
+function animate() {
+    requestAnimationFrame(animate);
+    if (audioPlaying && avatar) {
+        avatar.rotation.y += 0.01;
+    }
+    renderer.render(scene, camera);
+}
+animate();
+
+window.addEventListener('resize', () => {
+    camera.aspect = canvas.clientWidth / canvas.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+});
+
+const messagesDiv = document.getElementById('messages');
+const userInput = document.getElementById('userInput');
+const sendBtn = document.getElementById('sendBtn');
+let ws;
+
+function appendMessage(text, from='system') {
+    const div = document.createElement('div');
+    div.textContent = text;
+    div.style.color = from === 'user' ? '#0f0' : '#fff';
+    messagesDiv.appendChild(div);
+    messagesDiv.scrollTop = messagesDiv.scrollHeight;
+}
+
+function connect() {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    ws = new WebSocket(`${protocol}://${window.location.host}/client-ws`);
+    ws.onopen = () => appendMessage('Connected to server');
+    ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data);
+        if (msg.type === 'full-text' && msg.text) {
+            appendMessage(msg.text);
+        } else if (msg.type === 'audio' && msg.audio) {
+            playAudio(msg.audio, msg.actions);
+        }
+    };
+    ws.onclose = () => {
+        appendMessage('Connection closed, retrying...');
+        setTimeout(connect, 1000);
+    };
+}
+
+function setExpression(expr) {
+    const colors = [0x44aa88, 0xff5555, 0x5555ff, 0xffff55];
+    if (avatar) {
+        avatar.traverse((o) => {
+            if (o.isMesh && o.material && o.material.color) {
+                o.material.color.setHex(colors[expr % colors.length]);
+            }
+        });
+    }
+}
+
+function playAudio(base64Audio, actions) {
+    const audio = new Audio('data:audio/wav;base64,' + base64Audio);
+    audioPlaying = true;
+    audio.play();
+    if (actions && actions.expressions && actions.expressions.length) {
+        setExpression(actions.expressions[0]);
+    }
+    audio.onended = () => {
+        audioPlaying = false;
+        ws.send(JSON.stringify({ type: 'frontend-playback-complete' }));
+    };
+}
+
+sendBtn.addEventListener('click', () => {
+    const text = userInput.value.trim();
+    if (!text) return;
+    ws.send(JSON.stringify({type: 'text-input', text}));
+    appendMessage(text, 'user');
+    userInput.value = '';
+});
+
+connect();

--- a/src/open_llm_vtuber/server.py
+++ b/src/open_llm_vtuber/server.py
@@ -85,6 +85,14 @@ class WebSocketServer:
             name="web_tool",
         )
 
+        # Mount experimental three.js frontend
+        if os.path.isdir("frontend_threejs"):
+            self.app.mount(
+                "/threejs-demo",
+                CustomStaticFiles(directory="frontend_threejs", html=True),
+                name="threejs-demo",
+            )
+
         # Mount main frontend last (as catch-all)
         self.app.mount(
             "/",


### PR DESCRIPTION
## Summary
- implement more complete three.js demo
  - load a sample glTF avatar with `GLTFLoader`
  - add orbit controls, lighting, and simple animation
  - reconnect websocket automatically
- document the new demo and how to swap the model

## Testing
- `pytest -q`
