### PR TITLE
Fix threejs import issue

### DIFF
--- a/frontend_threejs/index.html
+++ b/frontend_threejs/index.html
@@ -19,7 +19,14 @@
         <input type="text" id="userInput" placeholder="Type your message" />
         <button id="sendBtn">Send</button>
     </div>
-    <script type="module" src="https://unpkg.com/three@0.160.0/build/three.module.js"></script>
+    <!-- Map the 'three' module specifier to the official CDN build -->
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://unpkg.com/three@0.160.0/build/three.module.js"
+        }
+    }
+    </script>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/frontend_threejs/main.js
+++ b/frontend_threejs/main.js
@@ -1,4 +1,5 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+// Import Three.js using the CDN path defined in the import map
+import * as THREE from 'three';
 
 const canvas = document.getElementById('renderArea');
 const scene = new THREE.Scene();


### PR DESCRIPTION
## Summary
- map `three` module to the CDN using an import map
- update demo to import `three` via the map
- remove the local placeholder `three.module.js`

## Testing
- `pytest -q`
