### PR TITLE
Add Three.js demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Checkout the [development guide](https://docs.llmvtuber.com/docs/development-gui
 [ylxmf2005/LLM-Live2D-Desktop-Assitant](https://github.com/ylxmf2005/LLM-Live2D-Desktop-Assitant)
 - Your Live2D desktop assistant powered by LLM! Available for both Windows and MacOS, it senses your screen, retrieves clipboard content, and responds to voice commands with a unique voice. Featuring voice wake-up, singing capabilities, and full computer control for seamless interaction with your favorite character.
 
+## 🕹️ Three.js Demo
+
+Run the server and visit [`/threejs-demo`](http://localhost:12393/threejs-demo/) to see a basic Three.js scene rendering a sample model. This page helps verify that your browser can display 3D avatars correctly.
+
 
 
 

--- a/src/open_llm_vtuber/server.py
+++ b/src/open_llm_vtuber/server.py
@@ -85,6 +85,14 @@ class WebSocketServer:
             name="web_tool",
         )
 
+        # Serve Three.js demo
+        if os.path.isdir("threejs-demo"):
+            self.app.mount(
+                "/threejs-demo",
+                CustomStaticFiles(directory="threejs-demo", html=True),
+                name="threejs_demo",
+            )
+
         # Mount main frontend last (as catch-all)
         self.app.mount(
             "/",

--- a/threejs-demo/README.md
+++ b/threejs-demo/README.md
@@ -1,0 +1,5 @@
+# Three.js Demo
+
+This folder contains a minimal example of rendering a 3D model using [Three.js](https://threejs.org/). It loads a sample glTF model from a public CDN and can be used to verify that your browser is able to display 3D content.
+
+To view the demo, start the Open-LLM-VTuber server and navigate to `http://localhost:12393/threejs-demo/` in your browser.

--- a/threejs-demo/index.html
+++ b/threejs-demo/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Three.js Avatar Demo</title>
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: #000;
+    }
+    #container {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/threejs-demo/main.js
+++ b/threejs-demo/main.js
@@ -1,0 +1,45 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.156/build/three.module.js';
+import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.156/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.156/examples/jsm/controls/OrbitControls.js';
+
+const container = document.getElementById('container');
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.set(0, 1.5, 3);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+container.appendChild(renderer.domElement);
+
+const light = new THREE.DirectionalLight(0xffffff, 1);
+light.position.set(1, 1, 1);
+scene.add(light);
+
+const loader = new GLTFLoader();
+loader.load(
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF/Box.gltf',
+  gltf => {
+    scene.add(gltf.scene);
+  },
+  undefined,
+  error => {
+    console.error('Error loading model:', error);
+  }
+);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+window.addEventListener('resize', onWindowResize);
+
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}
+animate();


### PR DESCRIPTION
## Summary
- serve a simple Three.js demo from `/threejs-demo`
- document the new demo in README
- provide minimal example HTML/JS files

## Testing
- `ruff check src/open_llm_vtuber/server.py`